### PR TITLE
runtime.GOMAXPROCS 관련한 내용 오류

### DIFF
--- a/Unit 33/go_closure_1.go
+++ b/Unit 33/go_closure_1.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	runtime.GOMAXPROCS(1) // CPU를 하나만 사용
+	runtime.GOMAXPROCS(1) // 시스템 스레드를 하나만 사용
 
 	s := "Hello, world!"
 


### PR DESCRIPTION
https://golang.org/pkg/runtime/ 해당 내용에 의하면, runtime.GOMAXPROCS 함수는 CPU 의 개수를 지정하는것이 아닌 시스템 스레드의 개수를 제한하는 함수입니다. 하지만, 주석에서는 CPU의 개수를 제한하는것이라고 적혀있어서 PR을 드려봅니다..